### PR TITLE
Refactor habit periods constant and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # About this project
 This project provides a simple habit tracker which can be user via a CLI.
 
+## Project structure
+The source code is located in the `src/` directory and is split into several
+packages:
+
+- `habit_tracking` – domain models such as `Habit` and `User`.
+- `habit_analysis` – functions for calculating streaks.
+- `data_storage` – storage backends, currently a JSON based implementation.
+- `cli_menu` – the command line interface.
+
+Common values such as the allowed habit periods are defined in `src/constants.py`.
+
 # Installation
 ## Installing python
 This project requires python 3.10 or higher. You can download python from [here](https://www.python.org/downloads/). 

--- a/src/cli_menu/habit_analysis_menu.py
+++ b/src/cli_menu/habit_analysis_menu.py
@@ -1,6 +1,7 @@
 from cli_menu.cli_utils import multi_page_option_selection_menu
 from habit_analysis import analytics
 from habit_tracking.users import User
+from constants import PERIODS
 
 
 def habit_analysis_menu(user: User):
@@ -70,12 +71,12 @@ def show_all_habits_with_current_streak_for_specific_periodicity(user: User):
     """
     print("--- Habits with current streak for specific periodicity ---")
     period = input(
-        "Enter habit tracking period (daily, weekly, monthly, quarterly, annually): "
+        "Enter habit tracking period (" + ", ".join(PERIODS) + "): "
     )
-    while period not in ["daily", "weekly", "monthly", "quarterly", "annually"]:
+    while period not in PERIODS:
         print(f"Invalid period {period}. Please try again.")
         period = input(
-            "Enter habit tracking period (daily, weekly, monthly, quarterly, annually): "
+            "Enter habit tracking period (" + ", ".join(PERIODS) + "): "
         )
     habits_with_streak = analytics.get_all_tracked_habits_with_streak_for_periodicity(
         user, period

--- a/src/cli_menu/habit_creation_menu.py
+++ b/src/cli_menu/habit_creation_menu.py
@@ -1,6 +1,7 @@
 from cli_menu.cli_utils import multi_page_option_selection_menu
 from data_storage.interface import StorageInterface
 from habit_tracking.habits import Habit
+from constants import PERIODS
 
 
 def habit_creation_menu(data_storage: StorageInterface):
@@ -50,12 +51,12 @@ def create_new_habit(data_storage: StorageInterface):
     else:
         habit_description = input("Enter habit task description: ")
         period = input(
-            "Enter habit tracking period (daily, weekly, monthly, quarterly, annually): "
+            "Enter habit tracking period (" + ", ".join(PERIODS) + "): "
         )
-        while period not in ["daily", "weekly", "monthly", "quarterly", "annually"]:
+        while period not in PERIODS:
             print(f"Invalid period {period}. Please try again.")
             period = input(
-                "Enter habit tracking period (daily, weekly, monthly, quarterly, annually): "
+                "Enter habit tracking period (" + ", ".join(PERIODS) + "): "
             )
         habit = Habit(habit_name, habit_description, period)
         data_storage.insert_habit(habit)

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,4 @@
+"""Shared constants for the habit tracker application."""
+
+#: Allowed periodicities for habits
+PERIODS = ["daily", "weekly", "monthly", "quarterly", "annually"]

--- a/src/habit_tracking/habits.py
+++ b/src/habit_tracking/habits.py
@@ -1,6 +1,8 @@
 import uuid
 from datetime import datetime, timedelta
 
+from constants import PERIODS
+
 
 class Habit:
     """
@@ -18,18 +20,14 @@ class Habit:
         Args:
             name: The name of the habit. Must be unique, since this value acts as the primary key.
             task_description: A description of the task to be completed as part of this habit.
-            period: The period over which the habit should be completed (daily, weekly, monthly, quarterly, annually).
+            period: The period over which the habit should be completed. Must be one of :data:`PERIODS`.
             creation_time: The time at which the habit was created. Defaults to the current time.
         """
         self.name = name
         self.task_description = task_description
-        assert period in [
-            'daily',
-            'weekly',
-            'monthly',
-            'quarterly',
-            'annually',
-        ], "Unsupported period type provided."
+        assert (
+            period in PERIODS
+        ), f"Unsupported period type provided. Allowed values: {', '.join(PERIODS)}"
         self.period = period
         self.creation_time = (
             creation_time if creation_time is not None else datetime.now()


### PR DESCRIPTION
## Summary
- centralize allowed habit periods in `constants.py`
- update `habit_creation_menu` and `habit_analysis_menu` to use the constant
- validate periods against constant in `Habit` class
- document project structure and new constant in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852650671948321be39130f4dc99e6c