### PR TITLE
Refactor analytics helpers and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,17 @@ After editing the parameters, you can run the file using the following command f
 python create_demo_data.py
 ```
 
+## Project structure
+The code base is organized into the following components:
+
+- `src/` – application modules
+  - `cli_menu` implements the interactive CLI.
+  - `habit_tracking` contains the domain models.
+  - `habit_analysis` provides streak analysis helpers.
+  - `data_storage` defines persistence interfaces and a JSON backend.
+- `tests/` – pytest unit tests covering the core functionality.
+- `main.py` – entry point launching the CLI.
+
 # Running pytests
 All important functions of this project are covered by pytest tests. You can install pytest using the following command:
 ```

--- a/src/habit_analysis/analytics.py
+++ b/src/habit_analysis/analytics.py
@@ -1,5 +1,52 @@
+"""Utility functions for analysing habit tracking statistics.
+
+The module exposes helpers to determine current and longest streaks for
+``UserHabit`` instances as well as convenience functions operating on an entire
+``User``.  The internal helper functions return streak lengths from a completion
+history and are reused by the public API.
+"""
+
 from habit_tracking.habits import Habit, UserHabit
 from habit_tracking.users import User
+
+
+def _longest_streak_from_history(
+    completion_history: list[tuple[object, object, bool]]
+) -> int:
+    """Return the longest streak from a completion history.
+
+    The ``completion_history`` list is expected to contain tuples of
+    ``(period_start, period_end, completed)``. Only the ``completed`` flag is
+    used for the calculation.
+    """
+    longest = 0
+    current = 0
+    for _, _, completed in completion_history:
+        if completed:
+            current += 1
+            longest = max(longest, current)
+        else:
+            current = 0
+    return longest
+
+
+def _current_streak_from_history(
+    completion_history: list[tuple[object, object, bool]]
+) -> int:
+    """Return the current streak from a completion history.
+
+    Incomplete periods at the end of the history are ignored before counting
+    consecutive ``True`` entries from the back of the list.
+    """
+    if completion_history and not completion_history[-1][2]:
+        completion_history = completion_history[:-1]
+    current = 0
+    for _, _, completed in reversed(completion_history):
+        if completed:
+            current += 1
+        else:
+            break
+    return current
 
 
 def get_all_tracked_habits_with_streak(user: User) -> list[tuple[Habit, int]]:
@@ -13,17 +60,8 @@ def get_all_tracked_habits_with_streak(user: User) -> list[tuple[Habit, int]]:
     """
     habits_with_streak = []
     for user_habit in user.habits:
-        completion_history = user_habit.get_completion_history()
-        # Remove the current period if it is not yet completed
-        completion_history = (
-            completion_history if completion_history[-1][2] else completion_history[:-1]
-        )
-        current_streak = 0
-        for _, _, completed in reversed(completion_history):
-            if completed:
-                current_streak += 1
-            else:
-                break
+        history = user_habit.get_completion_history()
+        current_streak = _current_streak_from_history(history)
         habits_with_streak.append((user_habit.habit, current_streak))
     return habits_with_streak
 
@@ -43,19 +81,8 @@ def get_all_tracked_habits_with_streak_for_periodicity(
     habits_with_streak = []
     for user_habit in user.habits:
         if user_habit.habit.period == period:
-            completion_history = user_habit.get_completion_history()
-            # Remove the current period if it is not yet completed
-            completion_history = (
-                completion_history
-                if completion_history[-1][2]
-                else completion_history[:-1]
-            )
-            current_streak = 0
-            for _, _, completed in reversed(completion_history):
-                if completed:
-                    current_streak += 1
-                else:
-                    break
+            history = user_habit.get_completion_history()
+            current_streak = _current_streak_from_history(history)
             habits_with_streak.append((user_habit.habit, current_streak))
     return habits_with_streak
 
@@ -71,18 +98,10 @@ def get_all_time_longest_habit_streak(user: User) -> tuple[Habit, int]:
     """
     longest_streak = (None, 0)
     for user_habit in user.habits:
-        completion_history = user_habit.get_completion_history()
-        longest_streak_for_habit = 0
-        current_streak = 0
-        for _, _, completed in completion_history:
-            if completed:
-                current_streak += 1
-            else:
-                longest_streak_for_habit = max(longest_streak_for_habit, current_streak)
-                current_streak = 0
-        longest_streak_for_habit = max(longest_streak_for_habit, current_streak)
-        if longest_streak_for_habit > longest_streak[1]:
-            longest_streak = (user_habit.habit, longest_streak_for_habit)
+        history = user_habit.get_completion_history()
+        streak = _longest_streak_from_history(history)
+        if streak > longest_streak[1]:
+            longest_streak = (user_habit.habit, streak)
     return longest_streak
 
 
@@ -97,19 +116,10 @@ def get_current_longest_habit_streak(user: User) -> tuple[Habit, int]:
     """
     longest_streak = (None, 0)
     for user_habit in user.habits:
-        completion_history = user_habit.get_completion_history()
-        # Remove the current period if it is not yet completed
-        completion_history = (
-            completion_history if completion_history[-1][2] else completion_history[:-1]
-        )
-        current_streak = 0
-        for _, _, completed in reversed(completion_history):
-            if completed:
-                current_streak += 1
-            else:
-                break
-        if current_streak > longest_streak[1]:
-            longest_streak = (user_habit.habit, current_streak)
+        history = user_habit.get_completion_history()
+        current = _current_streak_from_history(history)
+        if current > longest_streak[1]:
+            longest_streak = (user_habit.habit, current)
     return longest_streak
 
 
@@ -122,17 +132,8 @@ def get_longest_streak_for_habit(user_habit: UserHabit) -> int:
     Returns:
         The length of the longest streak for the habit.
     """
-    completion_history = user_habit.get_completion_history()
-    longest_streak = 0
-    current_streak = 0
-    for _, _, completed in completion_history:
-        if completed:
-            current_streak += 1
-        else:
-            longest_streak = max(longest_streak, current_streak)
-            current_streak = 0
-    longest_streak = max(longest_streak, current_streak)
-    return longest_streak
+    history = user_habit.get_completion_history()
+    return _longest_streak_from_history(history)
 
 
 def get_current_streak_for_habit(user_habit: UserHabit) -> int:
@@ -144,15 +145,5 @@ def get_current_streak_for_habit(user_habit: UserHabit) -> int:
     Returns:
         The length of the current streak for the habit.
     """
-    completion_history = user_habit.get_completion_history()
-    # Remove the current period if it is not yet completed
-    completion_history = (
-        completion_history if completion_history[-1][2] else completion_history[:-1]
-    )
-    current_streak = 0
-    for _, _, completed in reversed(completion_history):
-        if completed:
-            current_streak += 1
-        else:
-            break
-    return current_streak
+    history = user_habit.get_completion_history()
+    return _current_streak_from_history(history)


### PR DESCRIPTION
## Summary
- centralize streak calculations in analytics helper functions
- update `habit_analysis.analytics` documentation
- add project structure section to README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d0ba782f48321adbc15af3ec429a4