### PR TITLE
Add comprehensive tests for habit tracker logic and analytics

### DIFF
--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,67 @@
+import os, sys
+sys.path.append(os.path.abspath('src'))
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from habit_tracking.habits import Habit, UserHabit
+from habit_tracking.users import User
+from habit_analysis.analytics import (
+    get_all_tracked_habits_with_streak,
+    get_all_tracked_habits_with_streak_for_periodicity,
+    get_all_time_longest_habit_streak,
+    get_current_longest_habit_streak,
+    get_longest_streak_for_habit,
+    get_current_streak_for_habit,
+)
+
+
+@pytest.fixture
+def fixed_datetime(monkeypatch):
+    from habit_tracking import habits as habits_module
+
+    fixed_now = datetime(2024, 1, 15)
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now
+
+    monkeypatch.setattr(habits_module, 'datetime', FixedDateTime)
+    return fixed_now
+
+
+def build_user(fixed_datetime):
+    daily = Habit('daily', 'd', 'daily')
+    weekly = Habit('weekly', 'd', 'weekly')
+    uh_daily = UserHabit(habit=daily, creation_time=fixed_datetime - timedelta(days=5))
+    for days in [5, 4, 3, 2]:
+        uh_daily.track_completion(fixed_datetime - timedelta(days=days))
+    uh_weekly = UserHabit(habit=weekly, creation_time=fixed_datetime - timedelta(days=21))
+    uh_weekly.track_completion(fixed_datetime - timedelta(days=15))
+    uh_weekly.track_completion(fixed_datetime - timedelta(days=8))
+    user = User('alice', habits=[uh_daily, uh_weekly])
+    return user, uh_daily, uh_weekly
+
+
+def test_get_all_tracked_habits_with_streak(fixed_datetime):
+    user, uh_daily, uh_weekly = build_user(fixed_datetime)
+    result = get_all_tracked_habits_with_streak(user)
+    assert result == [(uh_daily.habit, 4), (uh_weekly.habit, 2)]
+
+
+def test_get_all_tracked_habits_with_streak_for_periodicity(fixed_datetime):
+    user, uh_daily, uh_weekly = build_user(fixed_datetime)
+    result = get_all_tracked_habits_with_streak_for_periodicity(user, 'daily')
+    assert result == [(uh_daily.habit, 4)]
+
+
+def test_longest_streaks(fixed_datetime):
+    user, uh_daily, uh_weekly = build_user(fixed_datetime)
+    habit, streak = get_all_time_longest_habit_streak(user)
+    assert habit == uh_daily.habit and streak == 4
+    habit, streak = get_current_longest_habit_streak(user)
+    assert habit == uh_daily.habit and streak == 4
+    assert get_longest_streak_for_habit(uh_weekly) == 2
+    assert get_current_streak_for_habit(uh_weekly) == 2

--- a/tests/test_habit_tracking.py
+++ b/tests/test_habit_tracking.py
@@ -1,0 +1,114 @@
+import os, sys
+sys.path.append(os.path.abspath('src'))
+
+from datetime import datetime, timedelta
+import pytest
+
+from habit_tracking.habits import Habit, UserHabit
+from habit_tracking.users import User
+
+
+@pytest.mark.parametrize(
+    'period,target,start,end',
+    [
+        ('daily', datetime(2024, 5, 4, 15), datetime(2024, 5, 4), datetime(2024, 5, 5)),
+        ('weekly', datetime(2024, 5, 4), datetime(2024, 4, 29), datetime(2024, 5, 6)),
+        ('monthly', datetime(2024, 5, 15), datetime(2024, 5, 1), datetime(2024, 6, 1)),
+        ('quarterly', datetime(2024, 7, 10), datetime(2024, 7, 1), datetime(2024, 10, 1)),
+        ('annually', datetime(2024, 5, 15), datetime(2024, 1, 1), datetime(2025, 1, 1)),
+    ],
+)
+def test_get_period_start_end(period, target, start, end):
+    habit = Habit('h', 'd', period)
+    s, e = habit.get_period_start_end(target)
+    assert s == start and e == end
+
+
+def test_get_next_period():
+    habit = Habit('h', 'd', 'monthly')
+    next_start, next_end = habit.get_next_period(datetime(2024, 12, 1))
+    assert next_start == datetime(2024, 12, 1)
+    assert next_end == datetime(2025, 1, 1)
+
+
+@pytest.fixture
+def fixed_datetime(monkeypatch):
+    from habit_tracking import habits as habits_module
+
+    fixed_now = datetime(2024, 1, 15)
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now
+
+    monkeypatch.setattr(habits_module, 'datetime', FixedDateTime)
+    return fixed_now
+
+
+def test_get_all_periods_since(fixed_datetime):
+    habit = Habit('h', 'd', 'daily')
+    start_time = fixed_datetime - timedelta(days=2, hours=1)
+    periods = habit.get_all_periods_since(start_time)
+    assert [p[0] for p in periods] == [
+        datetime(2024, 1, 12),
+        datetime(2024, 1, 13),
+        datetime(2024, 1, 14),
+    ]
+
+
+def test_habit_json():
+    creation = datetime(2024, 1, 1)
+    habit = Habit('h', 'desc', 'monthly', creation)
+    assert habit.json() == {
+        'name': 'h',
+        'task_description': 'desc',
+        'period': 'monthly',
+        'creation_time': creation.isoformat(),
+    }
+
+
+def test_userhabit_track_completion():
+    habit = Habit('h', 'd', 'daily')
+    user_habit = UserHabit(habit=habit)
+    time = datetime(2024, 1, 10, 10)
+    assert user_habit.track_completion(time)
+    assert not user_habit.track_completion(time + timedelta(hours=1))
+    assert user_habit.track_completion(time + timedelta(days=1))
+
+
+def test_userhabit_completion_history(fixed_datetime):
+    habit = Habit('h', 'd', 'daily')
+    creation = fixed_datetime - timedelta(days=2)
+    user_habit = UserHabit(habit=habit, creation_time=creation)
+    user_habit.track_completion(creation + timedelta(hours=1))
+    history = user_habit.get_completion_history()
+    assert history[0][2] is True
+    assert history[1][2] is False
+
+
+def test_userhabit_json():
+    habit = Habit('h', 'd', 'daily')
+    user_habit = UserHabit(habit=habit)
+    data = user_habit.json()
+    assert data['habit'] == 'h'
+    assert data['userhabit_id'] == user_habit.userhabit_id
+
+
+def test_user_add_remove_habit():
+    habit = Habit('h', 'd', 'daily')
+    user = User('alice')
+    user_habit = user.add_habit(habit)
+    assert user.get_userhabit_for_habit(habit) == user_habit
+    with pytest.raises(ValueError):
+        user.add_habit(habit)
+    removed = user.remove_habit(habit)
+    assert removed == user_habit
+    with pytest.raises(ValueError):
+        user.remove_habit(habit)
+
+
+def test_user_json():
+    habit = Habit('h', 'd', 'daily')
+    user = User('alice', habits=[UserHabit(habit=habit, userhabit_id='123')])
+    assert user.json() == {'username': 'alice', 'habits': ['123']}

--- a/tests/test_json_storage.py
+++ b/tests/test_json_storage.py
@@ -1,0 +1,61 @@
+import os, sys
+sys.path.append(os.path.abspath('src'))
+
+from datetime import datetime
+import pytest
+
+from habit_tracking.habits import Habit, UserHabit
+from habit_tracking.users import User
+from data_storage.json import JsonStorageInterface
+
+
+def test_storage_requires_json_extension(tmp_path):
+    with pytest.raises(AssertionError):
+        JsonStorageInterface(str(tmp_path / 'data.txt'))
+
+
+def test_user_operations(tmp_path):
+    storage = JsonStorageInterface(str(tmp_path / 'data.json'))
+    user = User('alice')
+    assert storage.insert_user(user)
+    assert not storage.insert_user(user)
+    fetched = storage.get_user('alice')
+    assert fetched.username == 'alice'
+    user.habits.append(UserHabit(habit=Habit('h', 'd', 'daily')))
+    assert storage.update_user(user)
+    fetched = storage.get_user('alice')
+    assert len(fetched.habits) == 1
+    assert storage.delete_user(user)
+    assert storage.get_user('alice') is None
+
+
+def test_habit_operations(tmp_path):
+    storage = JsonStorageInterface(str(tmp_path / 'data.json'))
+    habit = Habit('h', 'desc', 'daily')
+    assert storage.insert_habit(habit)
+    assert not storage.insert_habit(habit)
+    habit.task_description = 'new'
+    assert storage.update_habit(habit)
+    fetched = storage.get_habit('h')
+    assert fetched.task_description == 'new'
+    assert storage.get_all_habits()[0].name == 'h'
+    assert storage.delete_habit(habit)
+    assert storage.get_habit('h') is None
+
+
+def test_user_habit_operations(tmp_path):
+    storage = JsonStorageInterface(str(tmp_path / 'data.json'))
+    habit = Habit('h', 'd', 'daily')
+    storage.insert_habit(habit)
+    user_habit = UserHabit(habit=habit)
+    assert storage.insert_user_habit(user_habit)
+    assert not storage.insert_user_habit(user_habit)
+    user_habit.track_completion(datetime(2024, 1, 1))
+    assert storage.update_user_habit(user_habit)
+    fetched = storage.get_user_habit(user_habit.userhabit_id)
+    assert isinstance(fetched, UserHabit)
+    assert len(fetched.completion_times) == 1
+    assert len(storage.get_all_user_habits()) == 1
+    assert storage.delete_user_habit(user_habit)
+    assert storage.get_user_habit(user_habit.userhabit_id) is None
+


### PR DESCRIPTION
## Summary
- Add tests for habit and user entities covering period handling, tracking, and JSON serialization
- Add tests for JSON storage interface covering user, habit, and user-habit CRUD operations
- Add analytics tests verifying streak calculations across habits and periodicities

## Testing
- `pytest --maxfail=1 --disable-warnings -q`
- `pytest --cov=src/habit_tracking --cov=src/habit_analysis --cov=src/data_storage --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7bc388608832197bdde7210625fbd